### PR TITLE
Add winePath setting load on startup.

### DIFF
--- a/src/launchercore.cpp
+++ b/src/launchercore.cpp
@@ -332,6 +332,10 @@ void LauncherCore::readInitialInformation() {
             profile.winePrefixPath = getDefaultWinePrefixPath();
         }
 
+        if(settings.contains("winePath") && settings.value("winePath").canConvert<QString>() && !settings.value("winePath").toString().isEmpty()) {
+            profile.winePath = settings.value("winePath").toString();
+        }
+
         ProfileSettings defaultSettings;
 
         // login


### PR DESCRIPTION
Currently, winePath isn't loaded from the .ini file, resulting in an empty field and
the custom path being cleared from the .ini file on startup.