### PR TITLE
Steam Flatpak support

### DIFF
--- a/launcher/include/compatibilitytoolinstaller.h
+++ b/launcher/include/compatibilitytoolinstaller.h
@@ -26,7 +26,7 @@ public:
     bool hasSteam() const;
 
 Q_SIGNALS:
-    void installFinished();
+    void installFinished(bool flatpak);
     void error(QString message);
     void removalFinished();
     void isInstalledChanged();

--- a/launcher/include/compatibilitytoolinstaller.h
+++ b/launcher/include/compatibilitytoolinstaller.h
@@ -32,7 +32,12 @@ Q_SIGNALS:
     void isInstalledChanged();
 
 private:
-    QDir steamDir() const;
+    enum class SteamType {
+        NotFound,
+        Native,
+        Flatpak,
+    };
+    std::pair<SteamType, QDir> findSteamType() const;
 
     LauncherCore &m_launcher;
 };

--- a/launcher/src/compatibilitytoolinstaller.cpp
+++ b/launcher/src/compatibilitytoolinstaller.cpp
@@ -61,7 +61,7 @@ void CompatibilityToolInstaller::installCompatibilityTool()
         "\"manifest\"\n"
         "{\n"
         "  \"version\" \"2\"\n"
-        "  \"commandline\" \"/shell.sh \\\"$STEAM_RUNTIME/scripts/switch-runtime.sh\\\" --runtime=\\\"\\\" -- "
+        "  \"commandline\" \"/wrapper.sh \\\"$STEAM_RUNTIME/scripts/switch-runtime.sh\\\" --runtime=\\\"\\\" -- "
         "$STEAM_COMPAT_CLIENT_INSTALL_PATH/compatibilitytools.d/astra/run.sh %verb%\"\n"
         "}");
 

--- a/launcher/ui/Settings/CompatibilityToolSetup.qml
+++ b/launcher/ui/Settings/CompatibilityToolSetup.qml
@@ -7,6 +7,7 @@ import QtQuick.Controls as QQC2
 
 import org.kde.kirigami as Kirigami
 import org.kde.kirigamiaddons.formcard as FormCard
+import org.kde.kquickcontrolsaddons as KQuickControlsAddons
 
 import zone.xiv.astra
 
@@ -61,12 +62,26 @@ FormCard.FormCardPage {
         parent: page.QQC2.Overlay.overlay
     }
 
+    readonly property Kirigami.Action copyCommandAction: Kirigami.Action {
+        icon.name: "edit-copy-symbolic"
+        text: i18n("Copy Command")
+        onTriggered: clipboard.content = "flatpak override com.valvesoftware.Steam --talk-name=org.freedesktop.Flatpak"
+    }
+
+    readonly property KQuickControlsAddons.Clipboard clipboard: KQuickControlsAddons.Clipboard {}
+
     data: Connections {
         target: page.installer
 
-        function onInstallFinished(): void {
+        function onInstallFinished(flatpak: bool): void {
             page.errorDialog.title = i18n("Successful Installation");
-            page.errorDialog.subtitle = i18n("You need to relaunch Steam for Astra to show up as a Compatibility Tool.");
+            if (flatpak) {
+                page.errorDialog.subtitle = i18n("You need to relaunch Steam for Astra to show up as a Compatibility Tool.\n\nSince you are using the Steam Flatpak, you must give it permissions to allow it to launch Astra:\nflatpak override com.valvesoftware.Steam --talk-name=org.freedesktop.Flatpak");
+                page.errorDialog.customFooterActions = [copyCommandAction];
+            } else {
+                page.errorDialog.subtitle = i18n("You need to relaunch Steam for Astra to show up as a Compatibility Tool.");
+                page.errorDialog.customFooterActions = [];
+            }
             page.errorDialog.open();
         }
 

--- a/zone.xiv.astra.yml
+++ b/zone.xiv.astra.yml
@@ -14,6 +14,8 @@ finish-args:
   - --socket=fallback-x11
   - --share=network
   - --filesystem=home
+  # We need to install compatibility tools for Flatpak Steam
+  - --filesystem=~/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d/:rw
   - --socket=pulseaudio
   # Allow access to the GNOME secret service API and to talk to the GNOME keyring daemon
   - --talk-name=org.freedesktop.secrets

--- a/zone.xiv.astra.yml
+++ b/zone.xiv.astra.yml
@@ -128,6 +128,7 @@ modules:
       - -DBUILD_FLATPAK=ON
       - -DCMAKE_INSTALL_LIBDIR=/app/lib
       - -DLIB_INSTALL_DIR=/app/lib
+      - -DBUILD_TESTING=OFF
     build-options:
       build-args:
         - --share=network # needed for cargo unfortunately, flatpak has no native support (yet)

--- a/zone.xiv.astra.yml
+++ b/zone.xiv.astra.yml
@@ -88,7 +88,7 @@ modules:
     sources:
       - type: file
         url: https://xiv.zone/distrib/steamwrap/steamwrap
-        sha256: 86f798109366a8cb483c2cbd40116e2f34f533021eae18480c0ab7bd20fdf572
+        sha256: 196a7d07fcfa65dbb13a6cb37490926cd6c219875f0184f4c5aa156e99d2c454
   - name: steamapi
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
This adds support for interacting with the Steam Flatpak. Since Flatpak doesn't allow applications to launch one another, you need to give the Steam Flatpak access to the Flatpak DBus:

```
flatpak override com.valvesoftware.Steam --talk-name=org.freedesktop.Flatpak
```

This is of course, a giant security hole because it defeats the _security sandboxing_ of the Steam Flatpak and allows anything to run host binaries. But it's better than it not working at all, I guess!

(Astra still runs inside of its secure Flatpak sandbox.)

Fixes #35 