### PR TITLE
Switch to new Wine, add option to run on Wayland

### DIFF
--- a/launcher/config.kcfg
+++ b/launcher/config.kcfg
@@ -49,7 +49,7 @@ SPDX-License-Identifier: CC0-1.0
       <default>doitsujin/dxvk</default>
     </entry>
     <entry name="WineRepository" type="String">
-      <default>goatcorp/wine-xiv-git</default>
+      <default>rankynbass/unofficial-wine-xiv-git</default>
     </entry>
     <entry name="GithubApi" type="String">
       <default>api.github.com</default>

--- a/launcher/config.kcfg
+++ b/launcher/config.kcfg
@@ -54,5 +54,8 @@ SPDX-License-Identifier: CC0-1.0
     <entry name="GithubApi" type="String">
       <default>api.github.com</default>
     </entry>
+    <entry name="EnableWayland" type="bool">
+      <default>false</default>
+    </entry>
   </group>
 </kcfg>

--- a/launcher/src/gamerunner.cpp
+++ b/launcher/src/gamerunner.cpp
@@ -13,6 +13,7 @@
 #include "utility.h"
 
 #include <KProcessList>
+#include <QGuiApplication>
 
 using namespace Qt::StringLiterals;
 
@@ -340,6 +341,12 @@ void GameRunner::launchExecutable(const Profile &profile, QProcess *process, con
     const QString logDir = dataDir.absoluteFilePath(QStringLiteral("log"));
 
     env.insert(QStringLiteral("DXVK_LOG_PATH"), logDir);
+
+    // Enable the Wayland backend if we detect we're running on Wayland, otherwise fallback to X11.
+    if (QGuiApplication::platformName() == QStringLiteral("wayland") && m_launcher.config()->enableWayland()) {
+        // We have to unset the DISPLAY variable for Wine to pick it up.
+        env.remove(QStringLiteral("DISPLAY"));
+    }
 #endif
 
 #if defined(Q_OS_MAC) || defined(Q_OS_LINUX)

--- a/launcher/ui/Settings/DeveloperSettings.qml
+++ b/launcher/ui/Settings/DeveloperSettings.qml
@@ -85,6 +85,23 @@ FormCard.FormCardPage {
                 LauncherCore.config.save();
             }
         }
+
+        FormCard.FormDelegateSeparator {
+            above: renderDocCaptureDelegate
+            below: enableWaylandDelegate
+        }
+
+        FormCard.FormCheckDelegate {
+            id: enableWaylandDelegate
+
+            text: i18n("Run Game on Wayland")
+            description: i18n("Use the native Wine Wayland driver instead of going through XWayland.")
+            checked: LauncherCore.config.enableWayland
+            onCheckedChanged: {
+                LauncherCore.config.enableWayland = checked;
+                LauncherCore.config.save();
+            }
+        }
     }
 
     FormCard.FormHeader {


### PR DESCRIPTION
unofficial-wine-xiv-git is updated more often and has some nice FFXIV fixes that aren't present on wine-xiv-git. Additionally, add an option to enable the Wine Wayland driver in case you find it useful. I didn't make it the default for Wayland users because it's still very rough.