### PR TITLE
GameRunner: Escape spaces when building arguments

### DIFF
--- a/launcher/src/gamerunner.cpp
+++ b/launcher/src/gamerunner.cpp
@@ -286,7 +286,13 @@ QString GameRunner::getGameArgs(const Profile &profile, const std::optional<Logi
 
     QString argJoined;
     for (const auto &[key, value] : gameArgs) {
-        argJoined += argFormat.arg(key, value);
+        // We have to double-up on spaces, otherwise the encryption will destroy them. UserPath - for example - can contain spaces if the username does on
+        // Windows.
+        const auto escapeSpaces = [](QString string) {
+            return string.replace(QLatin1Char(' '), QStringLiteral("  "));
+        };
+
+        argJoined += argFormat.arg(escapeSpaces(key), escapeSpaces(value));
     }
 
     return !profile.config()->isBenchmark() && m_launcher.config()->encryptArguments() ? encryptGameArg(argJoined) : argJoined;


### PR DESCRIPTION
Easily seen on Windows, if the user has a space in their name.

Fixes #46