### PR TITLE
Don't require KFileMetaData on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,9 @@ find_package(KF6 ${KF_MIN_VERSION} REQUIRED COMPONENTS Kirigami I18n Config Core
 find_package(KF6KirigamiAddons 1.10.0 REQUIRED)
 find_package(QCoro6 REQUIRED COMPONENTS Core Network Qml)
 qcoro_enable_coroutines()
+if (LINUX)
+    find_package(KF6FileMetaData ${KF_MIN_VERSION} REQUIRED)
+endif ()
 
 qt_policy(SET QTP0001 NEW)
 qt_policy(SET QTP0004 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,11 +37,8 @@ find_package(Qt6 ${QT_MIN_VERSION} REQUIRED COMPONENTS
         Concurrent
         Test
         QmlPrivate) # QmlPrivate is here to work around a QCoro issue with 6.10, remove later
-if (LINUX)
-    find_package(Qt6 ${QT_MIN_VERSION} REQUIRED NO_MODULE COMPONENTS DBus)
-endif ()
 
-find_package(KF6 ${KF_MIN_VERSION} REQUIRED COMPONENTS Kirigami I18n Config CoreAddons Archive IconThemes FileMetaData)
+find_package(KF6 ${KF_MIN_VERSION} REQUIRED COMPONENTS Kirigami I18n Config CoreAddons Archive IconThemes GuiAddons)
 find_package(KF6KirigamiAddons 1.10.0 REQUIRED)
 find_package(QCoro6 REQUIRED COMPONENTS Core Network Qml)
 qcoro_enable_coroutines()

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -87,6 +87,7 @@ target_link_libraries(astra_static PUBLIC
         KF6::ConfigCore
         KF6::ConfigGui
         KF6::Archive
+        KF6::GuiAddons
         QCoro::Core
         QCoro::Network
         QCoro::Qml)
@@ -100,11 +101,6 @@ target_include_directories(astra_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/inclu
 
 if (NOT MSVC)
     target_compile_options(astra_static PUBLIC -fexceptions)
-endif ()
-
-# For screensaver inhibition on Linux
-if (TARGET Qt6::DBus)
-    target_link_libraries(astra_static PRIVATE Qt6::DBus)
 endif ()
 
 add_executable(astra)

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -89,8 +89,10 @@ target_link_libraries(astra_static PUBLIC
         KF6::Archive
         QCoro::Core
         QCoro::Network
-        QCoro::Qml
-        KF6::FileMetaData)
+        QCoro::Qml)
+if (LINUX)
+    target_link_libraries(astra_static PUBLIC KF6::FileMetaData)
+endif()
 kconfig_target_kcfg_file(astra_static FILE config.kcfg CLASS_NAME Config MUTATORS GENERATE_PROPERTIES GENERATE_MOC DEFAULT_VALUE_GETTERS PARENT_IN_CONSTRUCTOR QML_REGISTRATION QML_UNCREATABLE USE_ENUM_TYPES)
 kconfig_target_kcfg_file(astra_static FILE accountconfig.kcfg CLASS_NAME AccountConfig MUTATORS GENERATE_PROPERTIES GENERATE_MOC DEFAULT_VALUE_GETTERS PARENT_IN_CONSTRUCTOR QML_REGISTRATION QML_UNCREATABLE USE_ENUM_TYPES)
 kconfig_target_kcfg_file(astra_static FILE profileconfig.kcfg CLASS_NAME ProfileConfig MUTATORS GENERATE_PROPERTIES GENERATE_MOC DEFAULT_VALUE_GETTERS PARENT_IN_CONSTRUCTOR QML_REGISTRATION QML_UNCREATABLE USE_ENUM_TYPES)
@@ -103,7 +105,6 @@ endif ()
 # For screensaver inhibition on Linux
 if (TARGET Qt6::DBus)
     target_link_libraries(astra_static PRIVATE Qt6::DBus)
-    target_compile_definitions(astra_static PRIVATE -DHAS_DBUS)
 endif ()
 
 add_executable(astra)

--- a/launcher/include/launchercore.h
+++ b/launcher/include/launchercore.h
@@ -20,6 +20,7 @@ class GameInstaller;
 class CompatibilityToolInstaller;
 class GameRunner;
 class BenchmarkInstaller;
+class KSystemInhibitor;
 
 class LoginInformation : public QObject
 {
@@ -212,5 +213,5 @@ private:
 
     int m_currentProfileIndex = 0;
 
-    unsigned int screenSaverDbusCookie = 0;
+    KSystemInhibitor *m_inhibitor = nullptr;
 };

--- a/launcher/src/launchercore.cpp
+++ b/launcher/src/launchercore.cpp
@@ -3,7 +3,12 @@
 
 #include "gameinstaller.h"
 
+#ifdef Q_OS_LINUX
 #include <KFileMetaData/UserMetaData>
+#include <QDBusConnection>
+#include <QDBusReply>
+#include <QGuiApplication>
+#endif
 #include <KLocalizedString>
 #include <QCoroSignal>
 #include <QDir>
@@ -23,12 +28,6 @@
 #include "profileconfig.h"
 #include "squareenixlogin.h"
 #include "utility.h"
-
-#ifdef HAS_DBUS
-#include <QDBusConnection>
-#include <QDBusReply>
-#include <QGuiApplication>
-#endif
 
 using namespace Qt::StringLiterals;
 
@@ -650,7 +649,7 @@ void LauncherCore::updateConfig(const Account *account)
 
 void LauncherCore::inhibitSleep()
 {
-#ifdef HAS_DBUS
+#ifdef Q_OS_LINUX
     if (screenSaverDbusCookie != 0)
         return;
 
@@ -670,7 +669,7 @@ void LauncherCore::inhibitSleep()
 
 void LauncherCore::uninhibitSleep()
 {
-#ifdef HAS_DBUS
+#ifdef Q_OS_LINUX
     if (screenSaverDbusCookie == 0)
         return;
 
@@ -764,10 +763,12 @@ void LauncherCore::resetServerConfiguration(Account *account)
 
 QString LauncherCore::readHostPath(const QString &path)
 {
+#ifdef Q_OS_LINUX
     KFileMetaData::UserMetaData metadata(path);
     if (metadata.hasAttribute(QStringLiteral("document-portal.host-path"))) {
         return metadata.attribute(QStringLiteral("document-portal.host-path"));
     }
+#endif
 
     return path;
 }

--- a/launcher/src/launchercore.cpp
+++ b/launcher/src/launchercore.cpp
@@ -5,11 +5,9 @@
 
 #ifdef Q_OS_LINUX
 #include <KFileMetaData/UserMetaData>
-#include <QDBusConnection>
-#include <QDBusReply>
-#include <QGuiApplication>
 #endif
 #include <KLocalizedString>
+#include <KSystemInhibitor>
 #include <QCoroSignal>
 #include <QDir>
 #include <QImage>
@@ -25,6 +23,8 @@
 #include "compatibilitytoolinstaller.h"
 #include "gamerunner.h"
 #include "launchercore.h"
+
+#include "assetupdater.h"
 #include "profileconfig.h"
 #include "squareenixlogin.h"
 #include "utility.h"
@@ -649,38 +649,14 @@ void LauncherCore::updateConfig(const Account *account)
 
 void LauncherCore::inhibitSleep()
 {
-#ifdef Q_OS_LINUX
-    if (screenSaverDbusCookie != 0)
-        return;
-
-    QDBusMessage message = QDBusMessage::createMethodCall(QStringLiteral("org.freedesktop.ScreenSaver"),
-                                                          QStringLiteral("/ScreenSaver"),
-                                                          QStringLiteral("org.freedesktop.ScreenSaver"),
-                                                          QStringLiteral("Inhibit"));
-    message << QGuiApplication::desktopFileName();
-    message << i18n("Playing FFXIV");
-
-    const QDBusReply<uint> reply = QDBusConnection::sessionBus().call(message);
-    if (reply.isValid()) {
-        screenSaverDbusCookie = reply.value();
-    }
-#endif
+    uninhibitSleep(); // clean up the previous one (if any)
+    m_inhibitor = new KSystemInhibitor(i18n("Playing a game"), KSystemInhibitor::Type::Suspend, nullptr, this);
 }
 
 void LauncherCore::uninhibitSleep()
 {
-#ifdef Q_OS_LINUX
-    if (screenSaverDbusCookie == 0)
-        return;
-
-    QDBusMessage message = QDBusMessage::createMethodCall(QStringLiteral("org.freedesktop.ScreenSaver"),
-                                                          QStringLiteral("/ScreenSaver"),
-                                                          QStringLiteral("org.freedesktop.ScreenSaver"),
-                                                          QStringLiteral("UnInhibit"));
-    message << static_cast<uint>(screenSaverDbusCookie);
-    screenSaverDbusCookie = 0;
-    QDBusConnection::sessionBus().send(message);
-#endif
+    delete m_inhibitor;
+    m_inhibitor = nullptr;
 }
 
 QCoro::Task<> LauncherCore::beginAutoConfiguration(Account *account, QString url)


### PR DESCRIPTION
This is only used for a Flatpak (Linux) specific feature.